### PR TITLE
Fix name collision between function and callback

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -415,12 +415,12 @@ export function readRecipe({server, recipe}) {
             result => result.json(),
             error => dispatch(reportError('Could not read recipe'))
         ).then(
-            recipe => dispatch(updateRecipe({
-                recipe: recipe.name,
-                corpus: recipe.corpora,
-                source: recipe.source,
-                sink: recipe.sink,
-                classifier: recipe.classifier,
+            newRecipe => dispatch(updateRecipe({
+                recipe: newRecipe.name,
+                corpus: newRecipe.corpora,
+                source: newRecipe.source,
+                sink: newRecipe.sink,
+                classifier: newRecipe.classifier,
             })),
             error => dispatch(reportError('Could not convert recipe JSON'))
         ).then(


### PR DESCRIPTION
The function is called with a parameter "recipe" that collides
with the result name of a callback function. This changes the
name of the callback result to avoid the conflict.

Refs: #FBBL-WE-37