### PR TITLE
Cleaning actions file: beginAnalysis is not dispatched anywhere, so r…

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -64,12 +64,6 @@ export function prepareRecipes() {
     }
 }
 
-export function beginAnalysis() {
-    return {
-        type: BEGIN_ANALYSIS
-    }
-}
-
 export function endAnalysis() {
     return {
         type: END_ANALYSIS


### PR DESCRIPTION
As part of the ["Clean up unused actions"](https://github.com/filterbubbler/filterbubbler-web-ext/issues/59) issue, removing `beginAnalysis` function since it's not dispatched anywhere in the code.